### PR TITLE
Change panel category to ‘Panels’

### DIFF
--- a/foo_uie_typefind/main.cpp
+++ b/foo_uie_typefind/main.cpp
@@ -272,9 +272,10 @@ void TypefindWindow::get_name(pfc::string_base& out) const
 {
     out.set_string("Typefind");
 }
+
 void TypefindWindow::get_category(pfc::string_base& out) const
 {
-    out.set_string("Toolbars");
+    out.set_string("Panels");
 }
 
 void TypefindWindow::set_config(stream_reader* p_source, size_t p_size, abort_callback& p_abort)


### PR DESCRIPTION
This moves the panel from the ‘Toolbars’ category to the ‘Panels’ category, since it can’t actually be added to the toolbars area.